### PR TITLE
Add possibility to skip commits taking too long

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,12 @@ Extract refactorings from a given repository
 python3 main.py getrefs -r "[PATH_TO_REPOSITORY]"
 ```
 
+You can also use flag *-s* to skip the commit which takes more than N minutes to extract the refactorings. For example, the following command skips commits which were processed for more than 10 minutes:
+
+```sh
+python3 main.py getrefs -r "[PATH_TO_REPOSITORY]" -s 10 
+```
+
 If you want to look into specific commit, you can use flag *-c*.
 If you want to look into specific directory, you can use flag *-d*.
 

--- a/main.py
+++ b/main.py
@@ -54,6 +54,7 @@ extract_ref = subparsers.add_parser('getrefs', help='validate results')
 extract_ref.add_argument('-r', '--repopath', required=True, help='path to the repo')
 extract_ref.add_argument('-c', '--commit', required=False, help='specific commit hash')
 extract_ref.add_argument('-d', '--directory', required=False, help='specific directories', nargs='+')
+extract_ref.add_argument('-s', '--skip', required=False, help='skip commit after n minutes')
 extract_ref.set_defaults(func=extract_refs)
 
 

--- a/preprocessing/diff_list.py
+++ b/preprocessing/diff_list.py
@@ -110,6 +110,7 @@ def build_diff_lists(changes_path, commit=None, directory=None, skip_time=None):
         data["Commit"] = ref[1]
         json_outputs.append(data)
         # ref[0].to_graph()
+    changes_path = changes_path.replace('//', '/')
     repo_name = changes_path.split("/")[-3]
     with open(repo_name + '_data.json', 'w') as outfile:
         outfile.write(json.dumps(json_outputs, indent=4))

--- a/preprocessing/refactorings.py
+++ b/preprocessing/refactorings.py
@@ -57,8 +57,8 @@ class RenameRef(Refactoring):
                 final_info.append(rename_info)
             if "Param" in change:
                 if "Add" in change:
-                    print(change, self._param_change)
-                    print(self._from, self._removed_m.get_path_string(), self._to)
+                    # print(change, self._param_change)
+                    # print(self._from, self._removed_m.get_path_string(), self._to)
                     param_info = "The parameters [ %s ] are added to the method %s %s" % (
                     ' '.join(self._param_change[0]), self._from, self._removed_m.get_path_string())
                 if "Remove" in change:


### PR DESCRIPTION
In this request, we added the option to skip the commits which takes more than certain minutes to process with the flag "-s". Meanwhile, for a single commit, every 8 minutes a line will be printed to show that the process is still running.